### PR TITLE
Add support for `fetchPypi`

### DIFF
--- a/nix-update.el
+++ b/nix-update.el
@@ -44,6 +44,7 @@
                          (and "fetch"
                               (or "url"
                                   "git"
+                                  "Pypi"
                                   (and "FromGit" (or "Hub" "Lab"))))))
                     (1+ space)
                     "{"))
@@ -57,11 +58,22 @@
           (cl-flet ((get-field
                      (field)
                      (goto-char (point-min))
-                     (when (re-search-forward
-                            (concat field "\\s-+=\\s-+\"?\\(.+?\\)\"?\\s-*;")
-                            nil
-                            t)
-                       (match-string 1)))
+                     (let ((field-re (concat field "\\s-+=\\s-+\"?\\(.+?\\)\"?\\s-*;"))
+                           (res))
+                       (cond
+                        ((re-search-forward field-re nil t)
+                         (match-string 1))
+                        ((and (re-search-forward
+                               (concat "inherit\\s-+.*" field ".*;")
+                               nil
+                               t)
+                              (save-restriction
+                                (widen)
+                                (backward-up-list) (backward-up-list)
+                                (prog1
+                                    (re-search-forward field-re nil t)
+                                  (setq res (match-string 1)))))
+                         res))))
                     (set-field
                      (field value)
                      (goto-char (point-min))
@@ -169,6 +181,30 @@
                           (list
                            (cons 'date
                                  (format-time-string "%Y-%m-%dT%H:%M:%S%z"))
+                           (cons 'sha256
+                                 (buffer-substring
+                                  (line-beginning-position)
+                                  (line-end-position)))))))
+                     (`"fetchPypi"
+                      (let ((pname (get-field "pname"))
+                            (version (get-field "version")))
+                        (message "version: %s" version)
+                        (with-temp-buffer
+                          (message "Fetching PyPi Package: %s-%s: ..." pname version)
+                          (let ((inhibit-redisplay t))
+                            (shell-command
+                             (format
+                              "nix-prefetch-url mirror://pypi/%s/%s/%s-%s.tar.gz"
+                              (substring pname 0 1)
+                              pname
+                              pname
+                              version)
+                             (current-buffer))
+                            (message "Fetching PyPi Package: %s-%s: ...done" pname version))
+                          (goto-char (point-min))
+                          (while (looking-at "^\\(path is\\|warning\\)")
+                            (forward-line))
+                          (list
                            (cons 'sha256
                                  (buffer-substring
                                   (line-beginning-position)


### PR DESCRIPTION
Add support for updating fetchPypi expressions. This required a bit of
shuffling around because the usual idiom for defining python packages
looks like:

    hdfs = with pythonSuper; (buildPythonPackage rec {
      name = "${pname}-${version}";
      pname = "hdfs";
      version = "2.5.8";

      src = fetchPypi {
        inherit pname version;
        sha256 = "0w4kjjdbcqb7lbgrlbx0vcw3282svwaxrbjipiqmaa61kxa1gq8v";
      };

Specifically, the `inherit` bit there doesn't work with the way this was
previously extracting fields from the expressions - this works now via a
hacky pile of regex searching and narrowing (but hey, it works).

Fixes #7