### PR TITLE
Require json

### DIFF
--- a/nix-update.el
+++ b/nix-update.el
@@ -33,6 +33,7 @@
 ;;; Code:
 
 (require 'rx)
+(require 'json)
 
 (defun nix-update-fetch ()
   "Update the nix fetch expression at point."


### PR DESCRIPTION
Since we are using `json-read-object` we should also require `json`.