### PR TITLE
Allow specifying rev before fetching

### DIFF
--- a/nix-update.el
+++ b/nix-update.el
@@ -83,7 +83,7 @@
                      (`"fetchFromGitHub"
                       (let ((owner (get-field "owner"))
                             (repo (get-field "repo"))
-                            (rev (or (get-field "rev") "refs/heads/master"))
+                            (rev (or (get-field "rev") ""))
                             (submodules
                              (let ((subs (get-field "fetchSubmodules")))
                                (and subs (string-equal subs "true")))))
@@ -107,7 +107,7 @@
                      (`"fetchFromGitLab"
                       (let ((owner (get-field "owner"))
                             (repo (get-field "repo"))
-                            (rev (or (get-field "rev") "refs/heads/master")))
+                            (rev (or (get-field "rev") "")))
                         (with-temp-buffer
                           (message "Fetching GitLab repository: %s/%s ..."
                                    owner repo)
@@ -126,7 +126,7 @@
                           (json-read-object))))
                      (`"fetchgit"
                       (let ((url (get-field "url"))
-                            (rev (or (get-field "rev") "refs/heads/master")))
+                            (rev (or (get-field "rev") "")))
                         (with-temp-buffer
                           (message "Fetching Git URL: %s ..." url)
                           (let ((inhibit-redisplay t))


### PR DESCRIPTION
Allows setting a specific revision for git repositories (or leaving it blank to fetch master).
It also fixes some quoting issue when either rev or sha256 are not set and requires 'json (there's another PR for that but I also added it here).