### PR TITLE
Fix fetchFromGitHub

### DIFF
--- a/nix-update.el
+++ b/nix-update.el
@@ -94,7 +94,7 @@
                               (concat
                                "nix-prefetch-git --no-deepClone"
                                (if submodules " --fetch-submodules" "")
-                               " --quiet git://github.com/%s/%s.git %s")
+                               " --quiet https://github.com/%s/%s.git %s")
                               owner repo "refs/heads/master")
                              (current-buffer))
                             (message

--- a/nix-update.el
+++ b/nix-update.el
@@ -34,6 +34,7 @@
 
 (require 'rx)
 
+;;;###autoload
 (defun nix-update-fetch ()
   "Update the nix fetch expression at point."
   (interactive)

--- a/nix-update.el
+++ b/nix-update.el
@@ -95,8 +95,8 @@
                               (concat
                                "nix-prefetch-git --no-deepClone"
                                (if submodules " --fetch-submodules" "")
-                               " --quiet https://github.com/%s/%s.git %s")
-                              owner repo "refs/heads/master")
+                               " --quiet https://github.com/%s/%s.git")
+                              owner repo)
                              (current-buffer))
                             (message
                              "Fetching GitHub repository: %s/%s ...done"


### PR DESCRIPTION
- `git://` is deprecated, so use `https://` instead.
- Don't specify the ref.
- Also, add an autoload directive to `nix-update-fetch`.