### PR TITLE
Update hash correctly even when it originally equals to an empty string

### DIFF
--- a/nix-update.el
+++ b/nix-update.el
@@ -61,7 +61,7 @@
           (cl-flet ((get-field
                      (field)
                      (goto-char (point-min))
-                     (let ((field-re (concat field "\\s-+=\\s-+\"?\\(.+?\\)\"?\\s-*;"))
+                     (let ((field-re (concat field "\\s-+=\\s-+\"?\\(.*?\\)\"?\\s-*;"))
                            (res))
                        (cond
                         ((re-search-forward field-re nil t)
@@ -81,7 +81,7 @@
                      (field value)
                      (goto-char (point-min))
                      (if (re-search-forward
-                          (concat field "\\s-+=\\s-+\"?\\(.+?\\)\"?\\s-*;")
+                          (concat field "\\s-+=\\s-+\"?\\(.*?\\)\"?\\s-*;")
                           nil t)
                          (replace-match value nil t nil 1)
                        (goto-char (point-max))


### PR DESCRIPTION
If a fetcher is called with an empty hash, such as:

    sha256 = "";

Then, after calling nix-update-fetch, the line looks as follows:

    sha256 = "0m1ysnrg9xcf7rqa1vx90zjg3nv0s9wizq94h9p38r1znb8jl5wm;

See that the end quote is missing. This commit fixes that.