### PR TITLE
Update the hash field instead of sha256 if the original expression used it

### DIFF
--- a/nix-update.el
+++ b/nix-update.el
@@ -235,7 +235,12 @@
                                   (line-end-position))))))))))
               (if (assq 'rev data)
                   (set-field "rev" (alist-get 'rev data)))
-              (set-field "sha256" (alist-get 'sha256 data))
+              (if (get-field "hash")
+                  (set-field "hash" (or (alist-get 'hash data)
+                                        (string-trim
+                                         (shell-command-to-string
+                                          (concat "nix hash convert --hash-algo sha256 --to sri " (alist-get 'sha256 data))))))
+                (set-field "sha256" (alist-get 'sha256 data)))
               (if (assq 'date data)
                   (set-field "# date"
                              (let ((date (alist-get 'date data)))


### PR DESCRIPTION
Note that the recent version of `nix-prefetch-git` reports the SRI hash in addition to sha256 (see https://github.com/NixOS/nixpkgs/pull/240939).

If the prefetch command doesn't report the SRI hash (e.g. `nix-prefetch-url`), this commit converts the sha256 to SRI hash by running `nix hash convert`.